### PR TITLE
Updated rate limit timeout to 15 mintues

### DIFF
--- a/lib/twitter_ebooks/archive.rb
+++ b/lib/twitter_ebooks/archive.rb
@@ -92,8 +92,8 @@ module Ebooks
         begin
           new = @client.user_timeline(@username, opts)
         rescue Twitter::Error::TooManyRequests
-          log "Rate limit exceeded. Waiting for 5 mins before retry."
-          sleep 60*5
+          log "Rate limit exceeded. Waiting for 15 mins before retry."
+          sleep 60*15
           retry
         end
         break if new.length <= 1


### PR DESCRIPTION
Twitter keeps giving a large bot I’ve created extended rate limits
timeout due to using a 15 minute window. In order to prevent account
lockout for twitter_ebooks users, updating to 15 minutes.
https://dev.twitter.com/rest/public/rate-limiting